### PR TITLE
chore: replace the slack url to updated invite url

### DIFF
--- a/2022/README.md
+++ b/2022/README.md
@@ -4,7 +4,9 @@
 
 Welcome to the Keploy GSoC projects page. We encourage candidates to come up with their own project idea.
 
-Join our [Slack Channel](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA) and stay tuned for updates.
+Join our [Slack Channel][slack-invite] and stay tuned for updates.
+
+[slack-invite]: https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA
 
 Use our [Template](https://docs.google.com/document/d/1QSSs4vPvn_tPeJkhwDuJ9YLSXdtygob9cPc-5yXj3pY/edit?usp=sharing) for the proposal. We recommend the use of google docs for the proposal.
 

--- a/2022/README.md
+++ b/2022/README.md
@@ -4,7 +4,7 @@
 
 Welcome to the Keploy GSoC projects page. We encourage candidates to come up with their own project idea.
 
-Join our [Slack Channel](https://join.slack.com/t/keploy/shared_invite/zt-12rfbvc01-o54cOG0X1G6eVJTuI_orSA) and stay tuned for updates.
+Join our [Slack Channel](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA) and stay tuned for updates.
 
 Use our [Template](https://docs.google.com/document/d/1QSSs4vPvn_tPeJkhwDuJ9YLSXdtygob9cPc-5yXj3pY/edit?usp=sharing) for the proposal. We recommend the use of google docs for the proposal.
 

--- a/2023/README.md
+++ b/2023/README.md
@@ -4,7 +4,9 @@
 
 Welcome to the Keploy GSoC projects page. We encourage candidates to come up with their own project idea.
 
-Join our [Slack Channel](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA) and stay tuned for updates.
+Join our [Slack Channel][slack-invite] and stay tuned for updates.
+
+[slack-invite]: https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA
 
 Use our [Template](https://docs.google.com/document/d/1QSSs4vPvn_tPeJkhwDuJ9YLSXdtygob9cPc-5yXj3pY/edit?usp=sharing) for the proposal. We recommend the use of google docs for the proposal.
 

--- a/2023/README.md
+++ b/2023/README.md
@@ -4,7 +4,7 @@
 
 Welcome to the Keploy GSoC projects page. We encourage candidates to come up with their own project idea.
 
-Join our [Slack Channel](https://join.slack.com/t/keploy/shared_invite/zt-12rfbvc01-o54cOG0X1G6eVJTuI_orSA) and stay tuned for updates.
+Join our [Slack Channel](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA) and stay tuned for updates.
 
 Use our [Template](https://docs.google.com/document/d/1QSSs4vPvn_tPeJkhwDuJ9YLSXdtygob9cPc-5yXj3pY/edit?usp=sharing) for the proposal. We recommend the use of google docs for the proposal.
 

--- a/2024/README.md
+++ b/2024/README.md
@@ -4,7 +4,9 @@
 
 Welcome to the Keploy GSoC projects page. We encourage candidates to come up with their own project idea.
 
-Join our [Slack Channel](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA) and stay tuned for updates.
+Join our [Slack Channel][slack-invite] and stay tuned for updates.
+
+[slack-invite]: https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA
 
 Use our [Template](https://docs.google.com/document/d/1QSSs4vPvn_tPeJkhwDuJ9YLSXdtygob9cPc-5yXj3pY/edit?usp=sharing) for the proposal. We recommend the use of google docs for the proposal.
 

--- a/2024/README.md
+++ b/2024/README.md
@@ -4,7 +4,7 @@
 
 Welcome to the Keploy GSoC projects page. We encourage candidates to come up with their own project idea.
 
-Join our [Slack Channel](https://join.slack.com/t/keploy/shared_invite/zt-2dno1yetd-Ec3el~tTwHYIHgGI0jPe7A) and stay tuned for updates.
+Join our [Slack Channel](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA) and stay tuned for updates.
 
 Use our [Template](https://docs.google.com/document/d/1QSSs4vPvn_tPeJkhwDuJ9YLSXdtygob9cPc-5yXj3pY/edit?usp=sharing) for the proposal. We recommend the use of google docs for the proposal.
 

--- a/2025/README.md
+++ b/2025/README.md
@@ -2,7 +2,9 @@
 
 ## **Communication**
 
-Welcome to the Keploy GSoC'25 projects page. We encourage candidates to come up with their own project idea. Join our [Slack Channel](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA) and stay tuned for updates.
+Welcome to the Keploy GSoC'25 projects page. We encourage candidates to come up with their own project idea. Join our [Slack Channel][slack-invite] and stay tuned for updates.
+
+[slack-invite]: https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA
 
 Use our **[Template](https://docs.google.com/document/d/1yRWf5pXuUij-UwlXB9knDKqk9VYvV5GrNf865p77Y1U/edit?usp=sharing)** for the proposal. We recommend the use of google docs for the proposal.
 

--- a/2025/README.md
+++ b/2025/README.md
@@ -2,7 +2,7 @@
 
 ## **Communication**
 
-Welcome to the Keploy GSoC'25 projects page. We encourage candidates to come up with their own project idea. Join our [Slack Channel](https://keploy.slack.com/join/shared_invite/zt-2poflru6f-_VAuvQfCBT8fDWv1WwSbkw) and stay tuned for updates.
+Welcome to the Keploy GSoC'25 projects page. We encourage candidates to come up with their own project idea. Join our [Slack Channel](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA) and stay tuned for updates.
 
 Use our **[Template](https://docs.google.com/document/d/1yRWf5pXuUij-UwlXB9knDKqk9VYvV5GrNf865p77Y1U/edit?usp=sharing)** for the proposal. We recommend the use of google docs for the proposal.
 

--- a/2026/README.md
+++ b/2026/README.md
@@ -2,7 +2,9 @@
 
 ## **Communication**
 
-Welcome to the Keploy GSoC'26 projects page. We encourage candidates to come up with their own project idea. Join our [Slack Channel](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA) and stay tuned for updates.
+Welcome to the Keploy GSoC'26 projects page. We encourage candidates to come up with their own project idea. Join our [Slack Channel][slack-invite] and stay tuned for updates.
+
+[slack-invite]: https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA
 
 Use our **[Template](https://docs.google.com/document/d/1yRWf5pXuUij-UwlXB9knDKqk9VYvV5GrNf865p77Y1U/edit?usp=sharing)** for the proposal. We recommend the use of google docs for the proposal.
 

--- a/2026/README.md
+++ b/2026/README.md
@@ -2,7 +2,7 @@
 
 ## **Communication**
 
-Welcome to the Keploy GSoC'26 projects page. We encourage candidates to come up with their own project idea. Join our [Slack Channel]() and stay tuned for updates.
+Welcome to the Keploy GSoC'26 projects page. We encourage candidates to come up with their own project idea. Join our [Slack Channel](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA) and stay tuned for updates.
 
 Use our **[Template](https://docs.google.com/document/d/1yRWf5pXuUij-UwlXB9knDKqk9VYvV5GrNf865p77Y1U/edit?usp=sharing)** for the proposal. We recommend the use of google docs for the proposal.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,4 +99,4 @@ Every SDKs support the popular and common Routers and Databases.
 
 # Contact
 
-Feel free to join [slack](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA) to start a conversation with us.
+Feel free to join [Slack](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA) to start a conversation with us.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in Keploy and for taking the time to contribute to this project. 🙌 Keploy is a project by developers for developers and there are a lot of ways you can contribute.
 
-If you don't know where to start contributing, ask us on our [Slack channel](https://join.slack.com/t/keploy/shared_invite/zt-12rfbvc01-o54cOG0X1G6eVJTuI_orSA).
+If you don't know where to start contributing, ask us on our [Slack channel](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA).
 
 ## Code of conduct
 
@@ -99,4 +99,4 @@ Every SDKs support the popular and common Routers and Databases.
 
 # Contact
 
-Feel free to join [slack](https://join.slack.com/t/keploy/shared_invite/zt-12rfbvc01-o54cOG0X1G6eVJTuI_orSA) to start a conversation with us.
+Feel free to join [slack](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA) to start a conversation with us.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in Keploy and for taking the time to contribute to this project. 🙌 Keploy is a project by developers for developers and there are a lot of ways you can contribute.
 
-If you don't know where to start contributing, ask us on our [Slack channel](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA).
+If you don't know where to start contributing, ask us on our [Slack channel][slack-invite].
 
 ## Code of conduct
 
@@ -99,4 +99,6 @@ Every SDKs support the popular and common Routers and Databases.
 
 # Contact
 
-Feel free to join [Slack](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA) to start a conversation with us.
+Feel free to join [Slack][slack-invite] to start a conversation with us.
+
+[slack-invite]: https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA

--- a/GSoD 2023/Readme.md
+++ b/GSoD 2023/Readme.md
@@ -150,7 +150,9 @@ Our mentors Animesh Pathak, Sanskriti Harmukh, Ankit Kumar, Diganta Kr Banik, an
 
 Join the Keploy community and connect with mentors and other members through our Slack channel. 
 
-[![Join Keploy on Slack!](https://img.shields.io/badge/Join%20Us%20On-Slack-orange)](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA)
+[![Join Keploy on Slack!](https://img.shields.io/badge/Join%20Us%20On-Slack-orange)][slack-invite]
+
+[slack-invite]: https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA
  
 Follow us on Twitter and LinkedIn to stay up-to-date with the latest news and announcements:
 

--- a/GSoD 2023/Readme.md
+++ b/GSoD 2023/Readme.md
@@ -150,7 +150,7 @@ Our mentors Animesh Pathak, Sanskriti Harmukh, Ankit Kumar, Diganta Kr Banik, an
 
 Join the Keploy community and connect with mentors and other members through our Slack channel. 
 
-[![Join Keploy on Slack!](https://img.shields.io/badge/Join%20Us%20On-Slack-orange)](https://keploy.slack.com/)
+[![Join Keploy on Slack!](https://img.shields.io/badge/Join%20Us%20On-Slack-orange)](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA)
  
 Follow us on Twitter and LinkedIn to stay up-to-date with the latest news and announcements:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen?logo=github)](CODE_OF_CONDUCT.md) 
 [![Tests](https://github.com/keploy/keploy/actions/workflows/go.yml/badge.svg)](https://github.com/keploy/keploy/actions)
-[![Slack](.github/slack.svg)](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA)
+[![Slack](.github/slack.svg)][slack-invite]
 [![License](.github/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 # About Keploy
@@ -72,6 +72,8 @@ We encourage Contributors to set up Keploy for local development and play around
 
 ## Community support
 We'd love to collaborate with you to make Keploy great. To get started:
-* [Slack](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA) - Discussions with the community and the team.
+* [Slack][slack-invite] - Discussions with the community and the team.
 * [GitHub](https://github.com/keploy/keploy/issues) - For bug reports and feature requests.
+
+[slack-invite]: https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen?logo=github)](CODE_OF_CONDUCT.md) 
 [![Tests](https://github.com/keploy/keploy/actions/workflows/go.yml/badge.svg)](https://github.com/keploy/keploy/actions)
-[![Slack](.github/slack.svg)](https://join.slack.com/t/keploy/shared_invite/zt-12rfbvc01-o54cOG0X1G6eVJTuI_orSA)
+[![Slack](.github/slack.svg)](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA)
 [![License](.github/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 # About Keploy
@@ -72,6 +72,6 @@ We encourage Contributors to set up Keploy for local development and play around
 
 ## Community support
 We'd love to collaborate with you to make Keploy great. To get started:
-* [Slack](https://join.slack.com/t/keploy/shared_invite/zt-12rfbvc01-o54cOG0X1G6eVJTuI_orSA) - Discussions with the community and the team.
+* [Slack](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA) - Discussions with the community and the team.
 * [GitHub](https://github.com/keploy/keploy/issues) - For bug reports and feature requests.
 


### PR DESCRIPTION
## Summary

- Replace all stale Slack invite URLs across the repository with the current active invite link
- 8 files updated, 10 URL instances replaced (3 different expired tokens removed)
- Also fixes `2026/README.md` which had an empty Slack URL `()`
- Used a Markdown reference-style link in `README.md` so the URL is defined once and reused

## Files changed

| File | Change |
|---|---|
| `README.md` | 2 URLs updated, switched to reference-style link |
| `CONTRIBUTING.md` | 2 URLs updated, fixed `slack` → `Slack` capitalization |
| `2022/README.md` | 1 URL updated |
| `2023/README.md` | 1 URL updated |
| `2024/README.md` | 1 URL updated |
| `2025/README.md` | 1 URL updated |
| `2026/README.md` | Empty URL filled in |
| `GSoD 2023/Readme.md` | Workspace root URL updated to invite URL |

## New invite URL

`https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA`

## Note

This is a temporary fix to unblock contributors. The current approach of hardcoding invite tokens across multiple files requires manual updates every time the invite rotates.

The long-term plan is to set up a stable redirect (for example, a `keploy.io/slack` landing page or a similar mechanism that fetches the active invite URL from a single source of truth). That way, all docs point to one stable URL and only the redirect target needs to change when the invite rotates.
