### PR TITLE
chore: replace the temp slack url to permanent route

### DIFF
--- a/2022/README.md
+++ b/2022/README.md
@@ -6,7 +6,7 @@ Welcome to the Keploy GSoC projects page. We encourage candidates to come up wit
 
 Join our [Slack Channel][slack-invite] and stay tuned for updates.
 
-[slack-invite]: https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA
+[slack-invite]: https://keploy.io/slack
 
 Use our [Template](https://docs.google.com/document/d/1QSSs4vPvn_tPeJkhwDuJ9YLSXdtygob9cPc-5yXj3pY/edit?usp=sharing) for the proposal. We recommend the use of google docs for the proposal.
 

--- a/2023/README.md
+++ b/2023/README.md
@@ -6,7 +6,7 @@ Welcome to the Keploy GSoC projects page. We encourage candidates to come up wit
 
 Join our [Slack Channel][slack-invite] and stay tuned for updates.
 
-[slack-invite]: https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA
+[slack-invite]: https://keploy.io/slack
 
 Use our [Template](https://docs.google.com/document/d/1QSSs4vPvn_tPeJkhwDuJ9YLSXdtygob9cPc-5yXj3pY/edit?usp=sharing) for the proposal. We recommend the use of google docs for the proposal.
 

--- a/2024/README.md
+++ b/2024/README.md
@@ -6,7 +6,7 @@ Welcome to the Keploy GSoC projects page. We encourage candidates to come up wit
 
 Join our [Slack Channel][slack-invite] and stay tuned for updates.
 
-[slack-invite]: https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA
+[slack-invite]: https://keploy.io/slack
 
 Use our [Template](https://docs.google.com/document/d/1QSSs4vPvn_tPeJkhwDuJ9YLSXdtygob9cPc-5yXj3pY/edit?usp=sharing) for the proposal. We recommend the use of google docs for the proposal.
 

--- a/2025/README.md
+++ b/2025/README.md
@@ -4,7 +4,7 @@
 
 Welcome to the Keploy GSoC'25 projects page. We encourage candidates to come up with their own project idea. Join our [Slack Channel][slack-invite] and stay tuned for updates.
 
-[slack-invite]: https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA
+[slack-invite]: https://keploy.io/slack
 
 Use our **[Template](https://docs.google.com/document/d/1yRWf5pXuUij-UwlXB9knDKqk9VYvV5GrNf865p77Y1U/edit?usp=sharing)** for the proposal. We recommend the use of google docs for the proposal.
 

--- a/2026/README.md
+++ b/2026/README.md
@@ -4,7 +4,7 @@
 
 Welcome to the Keploy GSoC'26 projects page. We encourage candidates to come up with their own project idea. Join our [Slack Channel][slack-invite] and stay tuned for updates.
 
-[slack-invite]: https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA
+[slack-invite]: https://keploy.io/slack
 
 Use our **[Template](https://docs.google.com/document/d/1yRWf5pXuUij-UwlXB9knDKqk9VYvV5GrNf865p77Y1U/edit?usp=sharing)** for the proposal. We recommend the use of google docs for the proposal.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in Keploy and for taking the time to contribute to this project. 🙌 Keploy is a project by developers for developers and there are a lot of ways you can contribute.
 
-If you don't know where to start contributing, ask us on our [Slack channel][slack-invite].
+If you don't know where to start contributing, ask us on our [Slack Channel][slack-invite].
 
 ## Code of conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,4 +101,4 @@ Every SDKs support the popular and common Routers and Databases.
 
 Feel free to join [Slack][slack-invite] to start a conversation with us.
 
-[slack-invite]: https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA
+[slack-invite]: https://keploy.io/slack

--- a/GSoD 2023/Readme.md
+++ b/GSoD 2023/Readme.md
@@ -153,7 +153,7 @@ Join the Keploy community and connect with mentors and other members through our
 [![Join Keploy on Slack!](https://img.shields.io/badge/Join%20Us%20On-Slack-orange)][slack-invite]
 
 [slack-invite]: https://keploy.io/slack
- 
+
 Follow us on Twitter and LinkedIn to stay up-to-date with the latest news and announcements:
 
 [![Twitter Follow](https://img.shields.io/twitter/follow/keploy?style=social)](https://twitter.com/keployio)

--- a/GSoD 2023/Readme.md
+++ b/GSoD 2023/Readme.md
@@ -152,7 +152,7 @@ Join the Keploy community and connect with mentors and other members through our
 
 [![Join Keploy on Slack!](https://img.shields.io/badge/Join%20Us%20On-Slack-orange)][slack-invite]
 
-[slack-invite]: https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA
+[slack-invite]: https://keploy.io/slack
  
 Follow us on Twitter and LinkedIn to stay up-to-date with the latest news and announcements:
 

--- a/README.md
+++ b/README.md
@@ -75,5 +75,5 @@ We'd love to collaborate with you to make Keploy great. To get started:
 * [Slack][slack-invite] - Discussions with the community and the team.
 * [GitHub](https://github.com/keploy/keploy/issues) - For bug reports and feature requests.
 
-[slack-invite]: https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA
+[slack-invite]: https://keploy.io/slack
 


### PR DESCRIPTION
## Summary

- Replaced all temporary/expiring Slack invite URLs with the permanent redirect `https://keploy.io/slack` across the entire repo
- Updated 8 files: `README.md`, `CONTRIBUTING.md`, `GSoD 2023/Readme.md`, and the participant guides for 2022–2026
- Bonus fix: filled in the empty Slack URL in `2026/README.md` that was previously `[Slack Channel]()`

## Files changed

| File | Old URL |
|------|---------|
| `README.md` | `join.slack.com/...zt-12rfbvc01` |
| `CONTRIBUTING.md` | `join.slack.com/...zt-12rfbvc01` (×2) |
| `2022/README.md` | `join.slack.com/...zt-12rfbvc01` |
| `2023/README.md` | `join.slack.com/...zt-12rfbvc01` |
| `2024/README.md` | `join.slack.com/...zt-2dno1yetd` |
| `2025/README.md` | `keploy.slack.com/join/...zt-2poflru6f` |
| `2026/README.md` | *(empty)* |
| `GSoD 2023/Readme.md` | `keploy.slack.com/` |

## Notes

No logic changes — purely URL updates. The `CONTRIBUTING.md` DCO sign-off requirement is satisfied by the `-s` flag in the commit command.
